### PR TITLE
fix: Allow GQL or XHR client to be provided to UploadProvider.

### DIFF
--- a/src/clients/graphql/index.tsx
+++ b/src/clients/graphql/index.tsx
@@ -11,10 +11,14 @@ type GraphQLSetupOptions = {
   baseUrl: string;
   modifyRequest?: (request: GraphQLOptions) => GraphQLOptions;
 };
-export type GraphQLRequestOptions = {
+
+export type GraphQLClientProps = {
   onProgress: (progress: number) => void;
-  options: GraphQLOptions;
+  options: any;
 };
+
+export type GraphQLClient = (args: GraphQLClientProps) => Promise<XHRResponse>;
+
 type Headers = {
   [key: string]: any;
 };
@@ -38,7 +42,7 @@ export const createGraphQLClient = ({
 }: GraphQLSetupOptions) => ({
   onProgress,
   options,
-}: GraphQLRequestOptions): Promise<XHRResponse> => {
+}: GraphQLClientProps): Promise<XHRResponse> => {
   let modifiedOptions = modifyRequest ? modifyRequest(options) : options;
 
   const { clone, files } = extractFiles({

--- a/src/clients/xhr/index.tsx
+++ b/src/clients/xhr/index.tsx
@@ -7,7 +7,7 @@ export type XHRClientProps = {
   dispatch: dispatchType;
   onProgress: (progress: number) => void;
   files: FileOrFileList;
-  options: XHROptions;
+  options: any;
 };
 
 export type XHRClient = (args: XHRClientProps) => Promise<XHRResponse>;

--- a/src/provider.tsx
+++ b/src/provider.tsx
@@ -1,12 +1,13 @@
 import React, { ReactNode } from 'react';
 import { XHRClient } from './clients/xhr';
+import { GraphQLClient } from './clients/graphql';
 
 type Props = {
-  client: XHRClient | null;
+  client: XHRClient | GraphQLClient | null;
   children: ReactNode;
 };
 
-export const UploadContext = React.createContext<XHRClient | null>(null);
+export const UploadContext = React.createContext<XHRClient | GraphQLClient | null>(null);
 
 export const UploadProvider = ({ client, children }: Props) => (
   <UploadContext.Provider value={client}>{children}</UploadContext.Provider>

--- a/src/use-upload.tsx
+++ b/src/use-upload.tsx
@@ -10,11 +10,11 @@ import {
 } from './upload-reducer';
 import { XHRClient, XHROptions, createXhrClient } from './clients/xhr';
 import { FileOrFileList } from './';
-import { GraphQLOptions } from 'clients/graphql';
+import { GraphQLClient, GraphQLOptions } from 'clients/graphql';
 
 type HookProps = {
   files: File | FileList;
-  client: XHRClient | null;
+  client: XHRClient | GraphQLClient | null;
   options: XHROptions | GraphQLOptions;
   dispatch: dispatchType;
 };
@@ -34,7 +34,7 @@ const handleUpload = async ({
     files,
     options,
     dispatch,
-    onProgress: progress =>
+    onProgress: (progress: number) =>
       dispatch({ type: SET_UPLOAD_PROGRESS, payload: progress }),
   });
   if (response) dispatch({ type: FINISH_UPLOADING, payload: response });
@@ -44,7 +44,7 @@ export const useUpload = (
   files: FileOrFileList,
   options: XHROptions | GraphQLOptions,
 ): UploadState => {
-  let client = useContext<XHRClient | null>(UploadContext);
+  let client = useContext<XHRClient | GraphQLClient | null>(UploadContext);
   const [state, dispatch] = useReducer(reducer, {});
 
   useEffect(() => {


### PR DESCRIPTION
# Goal of PR

Works around the compile-time error described here: https://github.com/zackify/react-use-upload/issues/17

**This is definitely a work-around and not a proper fix.** It basically _removes_ the typings for the "client options" object.  Properly fixing this likely would involve considerably more refactoring.  As such, this may not be an acceptable change for the main branch.

However, the GraphQLClient doesn't seem to be usable as-is so I would argue that while far from perfect, this is an improvement.