### PR TITLE
feat: Initialize complete state, allow state to be cleared.

### DIFF
--- a/src/upload-reducer.tsx
+++ b/src/upload-reducer.tsx
@@ -33,7 +33,7 @@ export type dispatchType = (action: Action) => void;
 export function reducer(state: UploadState, action: Action): UploadState {
   switch (action.type) {
     case START_UPLOADING:
-      return { ...state, loading: true };
+      return { ...initialState, loading: true };
     case SET_UPLOAD_PROGRESS:
       return { ...state, progress: action.payload };
     case SET_ERROR:

--- a/src/upload-reducer.tsx
+++ b/src/upload-reducer.tsx
@@ -2,39 +2,57 @@ export const SET_ERROR = 'SET_ERROR';
 export const START_UPLOADING = 'START_UPLOADING';
 export const SET_UPLOAD_PROGRESS = 'SET_UPLOAD_PROGRESS';
 export const FINISH_UPLOADING = 'FINISH_UPLOADING';
+export const CLEAR_STATE = 'CLEAR_STATE';
 
 export type UploadState = {
-  loading?: boolean;
-  progress?: number;
-  error?: string;
-  done?: boolean;
+  loading: boolean;
+  progress: number;
+  error: string | null;
+  done: boolean;
   response?: any;
+};
+
+export const initialState: UploadState = {
+  loading: false,
+  progress: 0,
+  error: null,
+  done: false,
+  response: null
 };
 
 export type Action =
   | { type: 'START_UPLOADING' }
   | { type: 'SET_UPLOAD_PROGRESS'; payload: number }
   | { type: 'SET_ERROR'; payload: string }
-  | { type: 'FINISH_UPLOADING'; payload: any };
+  | { type: 'FINISH_UPLOADING'; payload: any }
+  | { type: 'CLEAR_STATE'; };
 
 export type dispatchType = (action: Action) => void;
+
 // The possible state changes that take place during a file upload
-export function reducer(state: UploadState, action: Action) {
+export function reducer(state: UploadState, action: Action): UploadState {
   switch (action.type) {
     case START_UPLOADING:
-      return { loading: true };
+      return { ...state, loading: true };
     case SET_UPLOAD_PROGRESS:
       return { ...state, progress: action.payload };
     case SET_ERROR:
-      return { loading: false, error: action.payload, done: true };
+      return { ...state, loading: false, error: action.payload, done: true };
     case FINISH_UPLOADING:
       return {
+        ...state,
         done: true,
         loading: false,
         response: action.payload,
         error: action.payload.error ? action.payload.response : false,
       };
+    case CLEAR_STATE:
+      return {
+        ...initialState
+      };
     default:
-      return state;
+      return {
+        ...state
+      };
   }
 }

--- a/src/upload-reducer.tsx
+++ b/src/upload-reducer.tsx
@@ -2,7 +2,7 @@ export const SET_ERROR = 'SET_ERROR';
 export const START_UPLOADING = 'START_UPLOADING';
 export const SET_UPLOAD_PROGRESS = 'SET_UPLOAD_PROGRESS';
 export const FINISH_UPLOADING = 'FINISH_UPLOADING';
-export const CLEAR_STATE = 'CLEAR_STATE';
+export const RESET = 'RESET';
 
 export type UploadState = {
   loading: boolean;
@@ -25,7 +25,7 @@ export type Action =
   | { type: 'SET_UPLOAD_PROGRESS'; payload: number }
   | { type: 'SET_ERROR'; payload: string }
   | { type: 'FINISH_UPLOADING'; payload: any }
-  | { type: 'CLEAR_STATE'; };
+  | { type: 'RESET'; };
 
 export type dispatchType = (action: Action) => void;
 
@@ -46,7 +46,7 @@ export function reducer(state: UploadState, action: Action): UploadState {
         response: action.payload,
         error: action.payload.error ? action.payload.response : false,
       };
-    case CLEAR_STATE:
+    case RESET:
       return {
         ...initialState
       };

--- a/src/upload-reducer.tsx
+++ b/src/upload-reducer.tsx
@@ -51,8 +51,6 @@ export function reducer(state: UploadState, action: Action): UploadState {
         ...initialState
       };
     default:
-      return {
-        ...state
-      };
+      return state;
   }
 }

--- a/src/use-upload.tsx
+++ b/src/use-upload.tsx
@@ -52,7 +52,6 @@ export const useUpload = (
 ): UseUploadResult => {
   let client = useContext<XHRClient | GraphQLClient | null>(UploadContext);
   const [state, dispatch] = useReducer(reducer, initialState);
-  const resetState = () => dispatch({ type: CLEAR_STATE });
 
   useEffect(() => {
     if (!files) return;
@@ -66,6 +65,6 @@ export const useUpload = (
 
   return {
     ...state,
-    reset: resetState
+    reset: () => dispatch({ type: CLEAR_STATE })
   };
 };

--- a/src/use-upload.tsx
+++ b/src/use-upload.tsx
@@ -42,13 +42,17 @@ const handleUpload = async ({
   if (response) dispatch({ type: FINISH_UPLOADING, payload: response });
 };
 
+type UseUploadResult = UploadState & {
+  reset: () => void
+}
+
 export const useUpload = (
   files: FileOrFileList,
   options: XHROptions | GraphQLOptions,
-): [UploadState, () => void] => {
+): UseUploadResult => {
   let client = useContext<XHRClient | GraphQLClient | null>(UploadContext);
   const [state, dispatch] = useReducer(reducer, initialState);
-  const clearState = () => dispatch({ type: CLEAR_STATE });
+  const resetState = () => dispatch({ type: CLEAR_STATE });
 
   useEffect(() => {
     if (!files) return;
@@ -60,5 +64,8 @@ export const useUpload = (
     });
   }, [files]);
 
-  return [state, clearState];
+  return {
+    ...state,
+    reset: resetState
+  };
 };

--- a/src/use-upload.tsx
+++ b/src/use-upload.tsx
@@ -8,7 +8,7 @@ import {
   FINISH_UPLOADING,
   dispatchType,
   initialState,
-  CLEAR_STATE,
+  RESET,
 } from './upload-reducer';
 import { XHRClient, XHROptions, createXhrClient } from './clients/xhr';
 import { FileOrFileList } from './';
@@ -65,6 +65,6 @@ export const useUpload = (
 
   return {
     ...state,
-    reset: () => dispatch({ type: CLEAR_STATE })
+    reset: () => dispatch({ type: RESET })
   };
 };

--- a/src/use-upload.tsx
+++ b/src/use-upload.tsx
@@ -7,6 +7,8 @@ import {
   SET_UPLOAD_PROGRESS,
   FINISH_UPLOADING,
   dispatchType,
+  initialState,
+  CLEAR_STATE,
 } from './upload-reducer';
 import { XHRClient, XHROptions, createXhrClient } from './clients/xhr';
 import { FileOrFileList } from './';
@@ -43,9 +45,10 @@ const handleUpload = async ({
 export const useUpload = (
   files: FileOrFileList,
   options: XHROptions | GraphQLOptions,
-): UploadState => {
+): [UploadState, () => void] => {
   let client = useContext<XHRClient | GraphQLClient | null>(UploadContext);
-  const [state, dispatch] = useReducer(reducer, {});
+  const [state, dispatch] = useReducer(reducer, initialState);
+  const clearState = () => dispatch({ type: CLEAR_STATE });
 
   useEffect(() => {
     if (!files) return;
@@ -57,5 +60,5 @@ export const useUpload = (
     });
   }, [files]);
 
-  return state;
+  return [state, clearState];
 };


### PR DESCRIPTION
# Goal of PR

- Always initializes the internal state using an `initialState` object.  This ensures that internal state is more predictable.
- Exposes a `resetState` function via `useUpload` so that the internal state can be reset.  This is useful if you want to recover from an error state or upload an additional file.

```javascript
const { loading, error, done, clear } = useUpload(...);
```