### PR TITLE
feat: If error message is blank empty string, fall back to default.

### DIFF
--- a/src/upload-reducer.tsx
+++ b/src/upload-reducer.tsx
@@ -44,7 +44,11 @@ export function reducer(state: UploadState, action: Action): UploadState {
         done: true,
         loading: false,
         response: action.payload,
-        error: action.payload.error ? action.payload.response : false,
+        error: action.payload.error
+          ? !!action.payload.response.length
+            ? action.payload.response
+            : 'An unknown error has occurred'
+          : false,
       };
     case RESET:
       return {


### PR DESCRIPTION
# Goal

Sometimes when errors occur (such as when a connection is refused), the error message comes back as an empty string.  This change falls back to a default message when this occurs.